### PR TITLE
support response + chat completion eps for prompt guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ A service providing a suite of `ext_proc` services for LLM use-cases:
 Currently, we offer a way to run a demo version of the service, alongside a pre-configured Envoy instance.
 
 ```bash
-# Build and run the Go service
-go build
-./inferno
-
-# Or use docker-compose
+# Builds `inferno` and deploys Envoy & configures it to use inferno filter
 docker-compose up --build
 ```
 
@@ -73,6 +69,8 @@ curl "http://localhost:10000/v1/completions" \
 
 #### Chat completion
 
+Chat completions:
+
 ```bash
 curl "http://localhost:10000/v1/chat/completions" \
   -H "Content-Type: application/json" \
@@ -85,6 +83,19 @@ curl "http://localhost:10000/v1/chat/completions" \
           "content": "Write a one-sentence bedtime story about Kubernetes."
         }
       ]
+  }'
+```
+
+
+Responses:
+
+```bash
+curl http://localhost:10000/v1/responses \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -d '{
+    "model": "gpt-4.1",
+    "input": "Tell me a three sentence bedtime story about Kubernetes."
   }'
 ```
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       context: ./
     environment:
       # Semantic Cache Settings
-      EMBEDDING_MODEL_SERVER: "${EMBEDDING_MODEL_SERVER:-http://192.168.97.4/v1/models/embedding-model:predict}"
+      EMBEDDING_MODEL_SERVER: "${EMBEDDING_MODEL_SERVER:-http://127.0.0.1/v1/models/embedding-model:predict}"
       EMBEDDING_MODEL_HOST: "${EMBEDDING_MODEL_HOST:-embedding-model-default.example.com}"
       SIMILARITY_THRESHOLD: "${SIMILARITY_THRESHOLD:-0.75}"
       

--- a/envoy/envoy.yaml
+++ b/envoy/envoy.yaml
@@ -49,6 +49,16 @@ static_resources:
                           #     "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
                           #     disabled: true
                         - match:
+                            prefix: "/v1/responses"
+                          route:
+                            cluster: openai_api
+                            timeout: 30s
+                            host_rewrite_literal: "api.openai.com"
+                          # typed_per_filter_config:
+                          #   envoy.filters.http.ext_proc:
+                          #     "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+                          #     disabled: true
+                        - match:
                             prefix: "/v1/embeddings"
                           route:
                             cluster: openai_api

--- a/internal/ext_proc/prompt_guard.go
+++ b/internal/ext_proc/prompt_guard.go
@@ -22,6 +22,7 @@ import (
 //  prompt parsing helpers
 
 // legacy `/v1/completions`
+// ref: https://platform.openai.com/docs/api-reference/completions
 func extractPromptFromCompletions(bodyMap map[string]interface{}) (string, bool) {
 	if p, ok := bodyMap["prompt"].(string); ok && p != "" {
 		return p, true
@@ -30,6 +31,7 @@ func extractPromptFromCompletions(bodyMap map[string]interface{}) (string, bool)
 }
 
 // `/v1/chat/completions`
+// ref: https://platform.openai.com/docs/api-reference/chat/create
 func extractPromptFromChat(bodyMap map[string]interface{}) (string, bool) {
 	if msgs, ok := bodyMap["messages"].([]interface{}); ok {
 		var parts []string
@@ -48,6 +50,7 @@ func extractPromptFromChat(bodyMap map[string]interface{}) (string, bool) {
 }
 
 // `/v1/responses`
+// ref: https://platform.openai.com/docs/api-reference/responses
 func extractPromptFromResponses(bodyMap map[string]interface{}) (string, bool) {
 	if inp, ok := bodyMap["input"].(string); ok && inp != "" {
 		return inp, true


### PR DESCRIPTION
Re: https://github.com/Kuadrant/kuadrant-operator/issues/1333

Extend support to support chat completions and response APIs.


```bash
curl http://localhost:10000/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -d '{
    "model": "gpt-4.1",
    "input": "Tell me a three sentence bedtime story about drugs."
  }'
{"error":"Prompt blocked by content policy"
```

```bash
curl http://localhost:10000/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -d '{
    "model": "gpt-4.1",
    "input": "Tell me a three sentence bedtime story about Kubernetes."
  }'
{
  "id": "resp_6819e65480bc8192ada55068941ce177087021f9ee6481ff",
  "object": "response",
  "created_at": 1746527828,
  "status": "completed",
  "error": null,
  "incomplete_details": null,
  "instructions": null,
  "max_output_tokens": null,
  "model": "gpt-4.1-2025-04-14",
  "output": [
    {
      "id": "msg_6819e65531ac81928f5ab436a1518a57087021f9ee6481ff",
      "type": "message",
      "status": "completed",
      "content": [
        {
          "type": "output_text",
          "annotations": [],
          "text": "Once upon a time, a cluster of friendly pods sailed through the Container Cloud, guided by the wise Captain Kube. Whenever storms of traffic or waves of errors appeared, the trusty controllers and nodes worked together to keep everything balanced and afloat. As night fell, every service rested peacefully, knowing the mighty Kubernetes watched over them, always ready for a new day\u2019s adventure."
        }
      ],
      "role": "assistant"
    }
  ],
  "parallel_tool_calls": true,
  "previous_response_id": null,
  "reasoning": {
    "effort": null,
    "summary": null
  },
  "service_tier": "default",
  "store": true,
  "temperature": 1.0,
  "text": {
    "format": {
      "type": "text"
    }
  },
  "tool_choice": "auto",
  "tools": [],
  "top_p": 1.0,
  "truncation": "disabled",
  "usage": {
    "input_tokens": 17,
    "input_tokens_details": {
      "cached_tokens": 0
    },
    "output_tokens": 75,
    "output_tokens_details": {
      "reasoning_tokens": 0
    },
    "total_tokens": 92
  },
  "user": null,
  "metadata": {}
}
```