### PR TITLE
adding kserve passthrough to the demo setup, in addition to openai

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,20 +4,23 @@ services:
   inferno_envoy:
     image: istio/proxyv2:1.15.0
     container_name: inferno_envoy
-    entrypoint: /usr/local/bin/envoy
+    entrypoint: /entrypoint.sh
     command: [
-      "--config-path", "/etc/envoy/envoy.yaml",
       "--log-level", "${ENVOY_LOG_LEVEL:-info}",
       "--service-cluster", "envoy-front",
       "--service-node", "envoy-front"
     ]
+    environment:
+      OPENAI_API_HOST: "${OPENAI_API_HOST:-api.openai.com}"
+      KSERVE_API_HOST: "${KSERVE_API_HOST:-192.168.97.4}"
+      KSERVE_API_HOST_HEADER: "${KSERVE_API_HOST_HEADER:-huggingface-llm-default.example.com}"
     ports:
       - 10000:10000
       - 15000:15000
     networks:
       - inferno-network
     volumes:
-      - ./envoy/envoy.yaml:/etc/envoy/envoy.yaml
+      - ./envoy/entrypoint.sh:/entrypoint.sh
 
   inferno_ext_proc:
     container_name: inferno_ext_proc

--- a/internal/ext_proc/cached_token_metrics_test.go
+++ b/internal/ext_proc/cached_token_metrics_test.go
@@ -1,0 +1,63 @@
+package ext_proc
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TokenMetricsWithCache", func() {
+	It("should extract token metrics from cached response in processor", func() {
+		responseWithMetrics := []byte(`{
+			"id": "chatcmpl-123",
+			"object": "chat.completion",
+			"created": 1677652288,
+			"model": "gpt-3.5-turbo",
+			"choices": [{
+				"message": {
+					"role": "assistant",
+					"content": "Hello, how can I help you today?"
+				},
+				"index": 0,
+				"finish_reason": "stop"
+			}],
+			"usage": {
+				"prompt_tokens": 50,
+				"completion_tokens": 75,
+				"total_tokens": 125
+			}
+		}`)
+
+		headers := ExtractTokenMetricsHeaders(responseWithMetrics)
+		Expect(headers).ToNot(BeNil(), "Should extract token metrics headers from response")
+		Expect(headers).To(HaveLen(3), "Should have 3 token metric headers")
+
+		headerMap := make(map[string]string)
+		for _, h := range headers {
+			headerMap[h.Header.Key] = h.Header.Value
+		}
+
+		Expect(headerMap["x-kuadrant-openai-prompt-tokens"]).To(Equal("50"), "Prompt tokens should be 50")
+		Expect(headerMap["x-kuadrant-openai-completion-tokens"]).To(Equal("75"), "Completion tokens should be 75")
+		Expect(headerMap["x-kuadrant-openai-total-tokens"]).To(Equal("125"), "Total tokens should be 125")
+	})
+
+	It("should handle responses with no token metrics", func() {
+		responseWithoutMetrics := []byte(`{
+			"id": "chatcmpl-123",
+			"object": "chat.completion",
+			"created": 1677652288,
+			"model": "gpt-3.5-turbo",
+			"choices": [{
+				"message": {
+					"role": "assistant",
+					"content": "Hello, how can I help you today?"
+				},
+				"index": 0,
+				"finish_reason": "stop"
+			}]
+		}`)
+
+		headers := ExtractTokenMetricsHeaders(responseWithoutMetrics)
+		Expect(headers).To(BeNil(), "Should not extract headers from response without metrics")
+	})
+})


### PR DESCRIPTION
Re: https://github.com/Kuadrant/kuadrant-operator/issues/1359


### Verification


Setup kServe w/ Kuadrant:

```bash
# with kserve-poc, run:
./kserve-setup.sh
./llm-setup.sh
./embedding-setup.sh
```

Run inferno:

```bash
gh pr checkout 12

# Setup kServe hosts
export KSERVE_API_HOST="$(kubectl get gateway -n kserve kserve-ingress-gateway -o jsonpath='{.status.addresses[0].value}')"
export KSERVE_API_HOST_HEADER="$(kubectl get inferenceservice huggingface-llm -o jsonpath='{.status.url}' | cut -d '/' -f 3)"
export EMBEDDING_MODEL_SERVER="http://$(kubectl get gateway -n kserve kserve-ingress-gateway -o jsonpath='{.status.addresses[0].value}')/v1/models/embedding-model:predict"
export EMBEDDING_MODEL_HOST="$(kubectl get inferenceservice embedding-model -o jsonpath='{.status.url}' | cut -d '/' -f 3)"

# note: no granite guardian host - set GUARDIAN_URL yourself, or ignore

docker compose up --build
```


Sample kServe requests:

```bash
curl "http://localhost:10000/openai/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -d '{
      "model": "llm",
      "messages": [
        {
          "role": "system",
          "content": "You are an assistant that speaks like Shakespeare."
        },
        {
          "role": "user",
          "content": "Write a poem about colors"
        }
      ],
      "max_tokens": 30,
      "stream": false
  }'
```


Should see token usage metrics headers, embedding and guardian checks (if configured).

Also verify existing OpenAI proxying:

```bash
curl -v "http://localhost:10000/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -d '{
      "model": "gpt-4.1",
      "messages": [
        {
          "role": "user",
          "content": "Write a one-sentence bedtime story about Kubernetes."
        }
      ]
  }'
```

Also fixes a bug where token usage metrics headers were not parsed & returned from semantic cached respones.

